### PR TITLE
Fix a typo in C++ language name

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -334,7 +334,7 @@ def build_gcc(*args):
     languages = 'c'
 
     if enable_cxx:
-        languages += ',cxx'
+        languages += ',c++'
 
     os.chdir(obj_directory)
 


### PR DESCRIPTION
There was a typo in my previous PR that I didn't notice.
The correct name for C++ in the `--enable-languages` option is 'c++', not 'cxx'